### PR TITLE
Update CommonResources.cfg

### DIFF
--- a/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/GameData/CommunityResourcePack/CommonResources.cfg
@@ -234,7 +234,7 @@ RESOURCE_DEFINITION
 	isTweakable = true
 } 
 
-RESOURCE_DEFINITION
+RESOURCE_DEFINITION:NEEDS[!RealFuels]
 {
 	name = LqdMethane // fuel for an engine, another fuel mode for all engines, not terribly important
 	density = 0.00186456


### PR DESCRIPTION
CRP's lqdMethane definition overwrites the one from RF, I believe this is the only case of conflict between the two. Since users of RF will definitely want RF's resources, this is the best way to ensure everything plays well together in every case as far as I can see. 