### PR TITLE
Update CRP.version to avoid KSP-AVC warning

### DIFF
--- a/GameData/CommunityResourcePack/CRP.version
+++ b/GameData/CommunityResourcePack/CRP.version
@@ -14,9 +14,9 @@
          "BUILD":0
      },
      "KSP_VERSION":{
-         "MAJOR":0,
-         "MINOR":90,
-         "PATCH":0
+         "MAJOR":1,
+         "MINOR":0,
+         "PATCH":2
      },
      "KSP_VERSION_MIN":{
          "MAJOR":0,

--- a/GameData/CommunityResourcePack/CRP.version
+++ b/GameData/CommunityResourcePack/CRP.version
@@ -24,8 +24,8 @@
          "PATCH":2
      },
      "KSP_VERSION_MAX":{
-         "MAJOR":0,
-         "MINOR":90,
-         "PATCH":0
+         "MAJOR":1,
+         "MINOR":0,
+         "PATCH":2
      }
  } 


### PR DESCRIPTION
This makes it so that KSP-AVC no longer marks it as out of date