### PR TITLE
Corrected Specific Heat Capacity of LqdHydrogen to Cryogenic storage …

### DIFF
--- a/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/GameData/CommunityResourcePack/CommonResources.cfg
@@ -298,7 +298,7 @@ RESOURCE_DEFINITION
 	name = LqdHydrogen // General propellant, used for high thrust electric engines
 	density = 0.00007085000
 	unitCost = 0.0367500
-	hsp = 14305 // specific heat capacity (kJ/tonne-K as units) // recalc, mols are for H2 on wiki
+	hsp = 9690 // specific heat capacity (kJ/tonne-K as units) at Crygenic Storage temperature
 	vsp = 448500 // heat of vapourization (KJ/tonne as units)  or 8.97 * 10^5 or 8.97E5?
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP


### PR DESCRIPTION
…temperature instead of Hydrogen Gas at room temperature

According to http://www.fsec.ucf.edu/en/publications/pdf/FSEC-CR-204-88-LiquidH2.pdf the Specific Heat Capacity of LqdHydrogen should be 9690 kJ / ton, not 14305 kJ /ton , which is the specific heat capacity of Hydrogen at room temperature!.