### PR TITLE
Increased cost of LqdHe3 from $2000/l to $5000/l

### DIFF
--- a/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/GameData/CommunityResourcePack/CommonResources.cfg
@@ -465,7 +465,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
-	unitCost = 2
+	unitCost = 5
 }
 
 RESOURCE_DEFINITION


### PR DESCRIPTION
Due to the difficulty of finding any natural resource of Helium3 and the wide range of application, and the limited production, the cost of Helium3 has risen to $5000 / liter and is expected to rise much higher as demands increase. Therefore the cost of Helium3 needs needs to increase at least to match current value.