### PR TITLE
Corrected Helium3 density and cost

### DIFF
--- a/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/GameData/CommunityResourcePack/CommonResources.cfg
@@ -461,11 +461,11 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
 	name = LqdHe3
-	density = 0.0001786
+	density = 0.000059
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
-	unitCost = 2
+	unitCost = 525.2
 }
 
 RESOURCE_DEFINITION


### PR DESCRIPTION
Corrected Helium3 density to real world value and restored Value to KSPI original cost. Real world cost would be even higher