### PR TITLE
Fixed Density Deuterium to real world data

### DIFF
--- a/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/GameData/CommunityResourcePack/CommonResources.cfg
@@ -451,7 +451,7 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
 	name = LqdDeuterium
-	density = 0.000086
+	density = 0.0001624
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true


### PR DESCRIPTION
Deuterium, heavy hydrogen, is significantly more dense than Hydrogen