### PR TITLE
Fixed Tritium to Real World Density

### DIFF
--- a/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/GameData/CommunityResourcePack/CommonResources.cfg
@@ -481,7 +481,7 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
 	name = LqdTritium
-	density = 0.000133
+	density = 0.000320
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true


### PR DESCRIPTION
Original data was obviously wrong, Tritium is of course even more dense than Deuterium