### PR TITLE
Fixed density LqdDeteurium and LqdTritium

### DIFF
--- a/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/GameData/CommunityResourcePack/CommonResources.cfg
@@ -453,7 +453,7 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
 	name = LqdDeuterium
-	density = 0.000086
+	density = 0.0001624
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
@@ -485,7 +485,7 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
 	name = LqdTritium
-	density = 0.000133
+	density = 0.000320
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true


### PR DESCRIPTION
Old data were place holders. Deteurium and Tritium are significantly more heavy than Hydrogen atoms