### PR TITLE
Implement resource visibility

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -13,6 +13,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+	isVisible = true
 	unitCost = 0.0000028637
 }
 
@@ -23,6 +24,7 @@ RESOURCE_DEFINITION
    flowMode = ALL_VESSEL
    transfer = PUMP
    isTweakable = true
+   isVisible = true
    unitCost = 16
 }
 
@@ -33,6 +35,7 @@ RESOURCE_DEFINITION
    flowMode = ALL_VESSEL
    transfer = PUMP
    isTweakable = true
+   isVisible = true
    unitCost = 0.3
    color = 1,1,0
 }
@@ -45,6 +48,7 @@ RESOURCE_DEFINITION
    transfer = PUMP
    unitCost = 160
    isTweakable = true
+   isVisible = true
 }
 
 RESOURCE_DEFINITION
@@ -55,6 +59,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+   	isVisible = true
 	unitCost = 0.238874700854701
 }
 
@@ -65,6 +70,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+   	isVisible = true
 	unitCost = 0.5000000
 }
 
@@ -76,6 +82,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+   	isVisible = true
 }
 
 RESOURCE_DEFINITION
@@ -86,6 +93,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW 
 	transfer = PUMP
 	isTweakable = true
+   	isVisible = true
 	color = 1,.5,0
 }
 
@@ -97,6 +105,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = false
+   	isVisible = true
 	color = 1,0,0
 }
 
@@ -108,6 +117,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+   	isVisible = true
 	hsp = 850
 }
 
@@ -119,6 +129,7 @@ RESOURCE_DEFINITION
   	flowMode = STACK_PRIORITY_SEARCH
   	transfer = PUMP
   	isTweakable = true
+   	isVisible = true
   	hsp = 2154
 }
 
@@ -130,6 +141,7 @@ RESOURCE_DEFINITION
     flowMode = ALL_VESSEL 
     transfer = PUMP
     isTweakable = true
+    isVisible = true
 }
 
 RESOURCE_DEFINITION
@@ -140,6 +152,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+   	isVisible = true
 }
 
 RESOURCE_DEFINITION
@@ -149,6 +162,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+   	isVisible = true
 	unitCost = 0.80
 	color = .75,0,1
 }
@@ -160,6 +174,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+   	isVisible = true
 	unitCost = 1.76
 	color = 0,1,1
 }
@@ -171,6 +186,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+   	isVisible = true
 	unitCost = 0.5
 }
 
@@ -181,6 +197,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+   	isVisible = true
 	unitCost = 0.000055836
 	color = 0,1,0	
 }
@@ -192,6 +209,7 @@ RESOURCE_DEFINITION
    flowMode = ALL_VESSEL
    transfer = PUMP
    isTweakable = true
+   isVisible = true
    unitCost = 8
 }
 
@@ -203,6 +221,7 @@ RESOURCE_DEFINITION
    transfer = PUMP
    unitCost = 140
    isTweakable = true
+   isVisible = true
 }
 
 RESOURCE_DEFINITION
@@ -212,6 +231,7 @@ RESOURCE_DEFINITION
    flowMode = ALL_VESSEL
    transfer = PUMP
    isTweakable = true
+   isVisible = true
    cost = 0.00001
 }
 
@@ -223,6 +243,7 @@ RESOURCE_DEFINITION
     flowMode = ALL_VESSEL 
 	transfer = PUMP
     isTweakable = true
+    isVisible = true
 }
 
 RESOURCE_DEFINITION
@@ -232,6 +253,7 @@ RESOURCE_DEFINITION
    flowMode = NO_FLOW
    transfer = NONE
    isTweakable = true
+   isVisible = true
    unitCost = 12.6
 }
 
@@ -242,6 +264,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0.3
 	color = 1,1,0
 }
@@ -253,6 +276,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0.7
 	color = 0,1,0
 }
@@ -265,6 +289,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0
 }
 
@@ -276,6 +301,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0
 }
 
@@ -287,6 +313,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0.0008
 	color = .5,.5,1
 }
@@ -303,6 +330,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	color = 1,0,0
 }
 
@@ -314,6 +342,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 }
 
 RESOURCE_DEFINITION
@@ -324,6 +353,7 @@ RESOURCE_DEFINITION
 	flowMode = NO_FLOW
 	transfer = NONE
 	isTweakable = true
+    isVisible = true
 }
 
 RESOURCE_DEFINITION
@@ -332,6 +362,7 @@ RESOURCE_DEFINITION
 	density = 0.01097000000
 	unitCost = 865.0000000
 	isTweakable = true
+    isVisible = true
 	flowMode = NO_FLOW
 	transfer = NONE
 }
@@ -346,6 +377,7 @@ RESOURCE_DEFINITION
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 }
 
 RESOURCE_DEFINITION
@@ -355,6 +387,8 @@ RESOURCE_DEFINITION
 	density = 0
 	flowMode = NO_FLOW
 	transfer = NONE
+	isTweakable = false
+    isVisible = true
 }
 
 //******************************
@@ -368,6 +402,7 @@ RESOURCE_DEFINITION
 	flowMode = NO_FLOW
 	transfer = NONE
 	isTweakable = false
+    isVisible = true
 	unitCost = 0
 }
 
@@ -378,6 +413,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 1.5
 }
 
@@ -388,6 +424,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0.5
 }
 
@@ -398,6 +435,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = false
+    isVisible = true
 	unitCost = 100
 }
 
@@ -408,6 +446,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = NONE
 	isTweakable = false
+    isVisible = true
 	unitCost = 0
 }
 
@@ -418,6 +457,7 @@ RESOURCE_DEFINITION
 	flowMode = NO_FLOW
 	transfer = NONE
 	isTweakable = false
+    isVisible = true
 	unitCost = 0
 }
 
@@ -428,6 +468,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = NONE
 	isTweakable = false
+    isVisible = true
 	unitCost = 0
 }
 
@@ -438,6 +479,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0.00336224
 }
 
@@ -448,6 +490,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = PUMP
 	isTweakable = false
+    isVisible = true
 	unitCost = 0
 }
 
@@ -458,6 +501,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0.0068
 }
 
@@ -468,6 +512,7 @@ RESOURCE_DEFINITION
    	flowMode = STAGE_PRIORITY_FLOW
    	transfer = PUMP
    	isTweakable = true
+    isVisible = true
    	unitCost = 0.0016
 }
 
@@ -478,6 +523,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0.27
 }
 
@@ -488,6 +534,7 @@ RESOURCE_DEFINITION
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0.00006785
 	hsp= 5170
 }
@@ -499,6 +546,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0.256
 }
 
@@ -509,6 +557,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 525.2
 	hsp = 4560
 }
@@ -520,6 +569,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0.0133
 	hsp = 4560
 }
@@ -531,6 +581,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 188
 	hsp = 9690
 }
@@ -542,6 +593,7 @@ RESOURCE_DEFINITION
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 0.0008240
 	hsp = 2040
 }
@@ -553,6 +605,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = NONE
 	isTweakable = false
+    isVisible = true
 	unitCost = 0
 }
 
@@ -563,6 +616,7 @@ RESOURCE_DEFINITION
 	flowMode = NO_FLOW
 	transfer = NONE
 	isTweakable = true
+    isVisible = true
 	unitCost = 0.019816
 }
 
@@ -573,6 +627,7 @@ RESOURCE_DEFINITION
    	flowMode = ALL_VESSEL
    	transfer = NONE
    	isTweakable = true
+    isVisible = true
    	unitCost = 73
 }
 
@@ -583,6 +638,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = NONE
 	isTweakable = true
+    isVisible = true
 	unitCost = 173
 }
 
@@ -594,6 +650,7 @@ RESOURCE_DEFINITION
   	flowMode = ALL_VESSEL
   	transfer = NONE
   	isTweakable = false
+    isVisible = true
 }
 
 RESOURCE_DEFINITION
@@ -603,6 +660,7 @@ RESOURCE_DEFINITION
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
+    isVisible = true
 	unitCost = 3718
 }
 
@@ -613,6 +671,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = NONE
 	isTweakable = false
+    isVisible = true
 	unitCost = 0
 }
 
@@ -624,6 +683,7 @@ RESOURCE_DEFINITION
 	flowMode = ALL_VESSEL
 	transfer = NONE
 	isTweakable = false
+    isVisible = true
 	unitCost = 0
 } 
 
@@ -641,6 +701,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Aerozine50
 }
 
@@ -653,6 +714,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/AK20
 }
 
@@ -665,6 +727,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/AK27
 }
 
@@ -677,6 +740,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Aniline
 }
 
@@ -689,6 +753,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/AvGas
 }
 
@@ -700,6 +765,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/CaveaB
 }
 
@@ -711,6 +777,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/ClF3
 }
 
@@ -722,6 +789,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/ClF5
 }
 
@@ -733,6 +801,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Diborane
 }
 
@@ -744,6 +813,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Ethane
 }
 
@@ -756,6 +826,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Ethanol75
 }
 
@@ -768,6 +839,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Ethanol75
 }
 
@@ -780,6 +852,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Ethanol75
 }
 
@@ -791,6 +864,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Ethylene
 }
 
@@ -802,6 +876,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/FLOX30
 }
 
@@ -813,6 +888,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/FLOX70
 }
 
@@ -824,6 +900,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/FLOX88
 }
 
@@ -836,6 +913,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Furfuryl
 }
 
@@ -847,6 +925,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Helium
 }
 
@@ -859,6 +938,7 @@ RESOURCE_DEFINITION
     flowMode = NO_FLOW
     transfer = NONE
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/HNIW
 }
 
@@ -871,6 +951,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/HTP
 }
 
@@ -883,6 +964,7 @@ RESOURCE_DEFINITION
     flowMode = NO_FLOW
     transfer = NONE
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/HTPB
 }
 
@@ -895,6 +977,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Hydrazine
 }
 
@@ -907,6 +990,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Hydyne
 }
 
@@ -919,6 +1003,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/IRFNA-III
 }
 
@@ -931,6 +1016,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/IRFNA-IV
 }
 
@@ -943,6 +1029,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/IWFNA
 }
 
@@ -955,6 +1042,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Kerosene
 }
 
@@ -967,6 +1055,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = false
     ksparpicon = RealFuels/Resources/ARPIcons/LeadBallast
 }
 
@@ -978,6 +1067,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/LqdFluorine
 }
 
@@ -991,6 +1081,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/LqdMethane
 }
 
@@ -1004,6 +1095,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/LqdOxygen
 }
 
@@ -1015,6 +1107,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Methane
 }
 
@@ -1027,6 +1120,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Methanol
 }
 
@@ -1039,6 +1133,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/MMH
 }
 
@@ -1051,6 +1146,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/MON1
 }
 
@@ -1063,6 +1159,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/MON3
 }
 
@@ -1075,6 +1172,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/MON10
 }
 
@@ -1087,6 +1185,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/MON15
 }
 
@@ -1099,6 +1198,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/MON20
 }
 
@@ -1111,6 +1211,7 @@ RESOURCE_DEFINITION
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = True
+    isVisible = true
 }
 
 RESOURCE_DEFINITION
@@ -1122,6 +1223,7 @@ RESOURCE_DEFINITION
     flowMode = NO_FLOW
     transfer = NONE
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/NGNC
 }
 
@@ -1133,6 +1235,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/N2F4
 }
 
@@ -1145,6 +1248,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Nitrogen
 }
 
@@ -1157,6 +1261,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/NitrousOxide
 }
 
@@ -1169,6 +1274,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/NTO
 }
 
@@ -1180,6 +1286,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/OF2
 }
 
@@ -1192,6 +1299,7 @@ RESOURCE_DEFINITION
     flowMode = NO_FLOW
     transfer = NONE
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/PBAN
 }
 
@@ -1203,6 +1311,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Pentaborane
 }
 
@@ -1215,6 +1324,7 @@ RESOURCE_DEFINITION
     flowMode = NO_FLOW
     transfer = NONE
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/PSPC
 }
 
@@ -1226,6 +1336,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Syntin
 }
 
@@ -1237,6 +1348,7 @@ RESOURCE_DEFINITION
     flowMode = NO_FLOW
     transfer = NONE
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/TEATEB
 }
 
@@ -1248,6 +1360,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Tonka250
 }
 
@@ -1259,6 +1372,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/Tonka500
 }
 
@@ -1271,6 +1385,7 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/UDMH
 }
 
@@ -1283,11 +1398,10 @@ RESOURCE_DEFINITION
     flowMode = STACK_PRIORITY_SEARCH
     transfer = PUMP
     isTweakable = True
+    isVisible = true
     ksparpicon = RealFuels/Resources/ARPIcons/UH25
 }
 
 //******************************
 //* END
 //******************************
-
-


### PR DESCRIPTION
Update the resource configurations to make use of the "isVisible" flag (implemented by KSP version 1.0.5).

NOTE: "IntakeAtm" is still visible and LeadBallast is now hidden.