### PR TITLE
Added Lithium6 isotope for Breeding and Fusion in KSPI-E

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -672,12 +672,24 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
 	name = Lithium
-	density = 0.00053400000
+	density = 0.000534
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true
     	isVisible = true
 	unitCost = 0.27
+	volume = 1
+}
+
+RESOURCE_DEFINITION
+{
+	name = Lithium6
+	density = 0.000458
+	flowMode = STAGE_PRIORITY_FLOW
+	transfer = PUMP
+	isTweakable = true
+    	isVisible = true
+	unitCost = 4
 	volume = 1
 }
 


### PR DESCRIPTION
Added Lithium6, an isotope of Lithium which is correct resource used to breed tritium in Nuclear Reactors and the most Fusion processes