### PR TITLE
Explicitly add icons for KSPARP where they already exist.

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -57,6 +57,7 @@ RESOURCE_DEFINITION
     isTweakable = True
     isVisible = true
 	volume = 1
+    ksparpicon = RealFuels/Resources/ARPIcons/LeadBallast
 }
 
 
@@ -70,6 +71,7 @@ RESOURCE_DEFINITION
 	isVisible = true
 	unitCost = 0.0000028637
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/CarbonDioxide
 }
 
 RESOURCE_DEFINITION
@@ -107,6 +109,7 @@ RESOURCE_DEFINITION
    isTweakable = true
    isVisible = true
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/ExoticMatter
 }
 
 RESOURCE_DEFINITION
@@ -120,6 +123,7 @@ RESOURCE_DEFINITION
    	isVisible = true
 	unitCost = 0.238874700854701
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Food
 }
 
 RESOURCE_DEFINITION
@@ -131,6 +135,7 @@ RESOURCE_DEFINITION
    unitCost = 2.5
    isTweakable = true
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Supplies
 }
 
 RESOURCE_DEFINITION
@@ -142,6 +147,7 @@ RESOURCE_DEFINITION
    unitCost = 2
    isTweakable = true
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Fertilizer
 }
 
 RESOURCE_DEFINITION
@@ -153,6 +159,7 @@ RESOURCE_DEFINITION
    unitCost = 0
    isTweakable = true
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Mulch
 }
 
 RESOURCE_DEFINITION
@@ -198,6 +205,7 @@ RESOURCE_DEFINITION
 	isTweakable = true
    	isVisible = true
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Hydrogen
 }
 
 RESOURCE_DEFINITION
@@ -237,6 +245,7 @@ RESOURCE_DEFINITION
    	isVisible = true
 	hsp = 850
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/CarbonDioxide
 }
 
 RESOURCE_DEFINITION
@@ -274,6 +283,7 @@ RESOURCE_DEFINITION
 	isTweakable = true
    	isVisible = true
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Metal
 }
 
 RESOURCE_DEFINITION
@@ -325,6 +335,7 @@ RESOURCE_DEFINITION
 	unitCost = 0.000055836
 	color = 0,1,0	
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Oxygen
 }
 
 RESOURCE_DEFINITION
@@ -375,6 +386,7 @@ RESOURCE_DEFINITION
     isTweakable = true
     isVisible = true
 	volume = 5
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/RocketParts
 }
 
 RESOURCE_DEFINITION
@@ -426,6 +438,7 @@ RESOURCE_DEFINITION
     isVisible = true
 	unitCost = 0
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Waste
 }
 
 RESOURCE_DEFINITION
@@ -439,6 +452,7 @@ RESOURCE_DEFINITION
     isVisible = true
 	unitCost = 0
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/WasteWater
 }
 
 RESOURCE_DEFINITION
@@ -453,6 +467,7 @@ RESOURCE_DEFINITION
 	unitCost = 0.0008
 	color = .5,.5,1
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Water
 }
 
 //******************************
@@ -470,6 +485,7 @@ RESOURCE_DEFINITION
     isVisible = true
 	color = 1,0,0
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Argon
 }
 
 RESOURCE_DEFINITION
@@ -494,6 +510,7 @@ RESOURCE_DEFINITION
 	isTweakable = true
     isVisible = true
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/DepletedUranium
 }
 
 RESOURCE_DEFINITION
@@ -506,6 +523,7 @@ RESOURCE_DEFINITION
 	flowMode = NO_FLOW
 	transfer = NONE
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/EnrichedUranium
 }
 
 RESOURCE_DEFINITION
@@ -520,6 +538,7 @@ RESOURCE_DEFINITION
 	isTweakable = true
     isVisible = true
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/LiquidHydrogen
 }
 
 RESOURCE_DEFINITION
@@ -532,6 +551,7 @@ RESOURCE_DEFINITION
 	isTweakable = false
     isVisible = true
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/StoredCharge
 }
 
 //******************************
@@ -548,6 +568,7 @@ RESOURCE_DEFINITION
     isVisible = true
 	unitCost = 0
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Actinides
 }
 
 RESOURCE_DEFINITION
@@ -560,6 +581,7 @@ RESOURCE_DEFINITION
     isVisible = true
 	unitCost = 1.5
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Aluminium
 }
 
 RESOURCE_DEFINITION
@@ -572,6 +594,7 @@ RESOURCE_DEFINITION
     	isVisible = true
 	unitCost = 0.5
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Alumina
 }
 
 RESOURCE_DEFINITION
@@ -584,6 +607,7 @@ RESOURCE_DEFINITION
     	isVisible = true
 	unitCost = 100
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/AntiMatter
 }
 
 RESOURCE_DEFINITION
@@ -606,6 +630,7 @@ RESOURCE_DEFINITION
 	isTweakable = false
     	isVisible = true
 	unitCost = 0
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/ChargedParticles
 }
 
 RESOURCE_DEFINITION
@@ -618,6 +643,7 @@ RESOURCE_DEFINITION
     isVisible = true
 	unitCost = 0
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/DepletedFuel
 }
 
 RESOURCE_DEFINITION
@@ -630,6 +656,7 @@ RESOURCE_DEFINITION
     	isVisible = true
 	unitCost = 0
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/ExoticMatter
 }
 
 RESOURCE_DEFINITION
@@ -654,6 +681,7 @@ RESOURCE_DEFINITION
     	isVisible = true
 	unitCost = 0
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/IntakeAtm
 }
 
 RESOURCE_DEFINITION
@@ -690,6 +718,7 @@ RESOURCE_DEFINITION
     	isVisible = true
 	unitCost = 0.27
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Lithium
 }
 
 RESOURCE_DEFINITION
@@ -715,6 +744,7 @@ RESOURCE_DEFINITION
 	unitCost = 0.00006785
 	hsp= 5170
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/LqdAmmonia
 }
 
 RESOURCE_DEFINITION
@@ -740,6 +770,7 @@ RESOURCE_DEFINITION
     	unitCost = 1.1127
     	hsp = 4560
     	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Helium-3
 }
 
 RESOURCE_DEFINITION
@@ -766,6 +797,7 @@ RESOURCE_DEFINITION
 	unitCost = 0.0133
 	hsp = 4560
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/LqdHelium
 }
 
 RESOURCE_DEFINITION
@@ -804,6 +836,7 @@ RESOURCE_DEFINITION
     	isVisible = true
 	unitCost = 0
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Megajoules
 }
 
 RESOURCE_DEFINITION
@@ -830,6 +863,7 @@ RESOURCE_DEFINITION
     	isVisible = true
 	unitCost = 4000
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Plutonium-238
 }
 
 RESOURCE_DEFINITION
@@ -842,6 +876,7 @@ RESOURCE_DEFINITION
     	isVisible = true
    	unitCost = 72
    	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/UF4
 }
 
 RESOURCE_DEFINITION
@@ -854,6 +889,7 @@ RESOURCE_DEFINITION
     	isVisible = true
 	unitCost = 18
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/ThF4
 }
 
 RESOURCE_DEFINITION
@@ -865,6 +901,7 @@ RESOURCE_DEFINITION
   	transfer = NONE
   	isTweakable = false
     	isVisible = true
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/ThermalPower
 }
 
 RESOURCE_DEFINITION
@@ -877,6 +914,7 @@ RESOURCE_DEFINITION
     	isVisible = true
 	unitCost = 3718
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/UraniumNitride
 }
 
 RESOURCE_DEFINITION
@@ -889,6 +927,7 @@ RESOURCE_DEFINITION
     	isVisible = true
 	unitCost = 0
 	volume = 1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/VacuumPlasma
 }
 
 
@@ -901,6 +940,7 @@ RESOURCE_DEFINITION
 	isTweakable = false
     	isVisible = true
 	unitCost = 0
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/WasteHeat
 } 
 
 //******************************
@@ -918,7 +958,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/Aerozine50
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Aerozine
 }
 
 RESOURCE_DEFINITION
@@ -1142,7 +1182,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/Helium
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Helium
 }
 
 RESOURCE_DEFINITION
@@ -1194,7 +1234,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/Hydrazine
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Hydrazine
 }
 
 RESOURCE_DEFINITION
@@ -1207,7 +1247,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/Hydyne
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Hydyne
 }
 
 RESOURCE_DEFINITION
@@ -1259,7 +1299,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/Kerosene
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Kerosene
 }
 
 RESOURCE_DEFINITION
@@ -1298,7 +1338,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/LqdMethane
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/LqdMethane
 }
 
 RESOURCE_DEFINITION
@@ -1312,7 +1352,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/LqdOxygen
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/LiquidOxygen
 }
 
 RESOURCE_DEFINITION
@@ -1350,7 +1390,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/MMH
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/MMH
 }
 
 RESOURCE_DEFINITION
@@ -1363,7 +1403,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/MON1
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/MON1
 }
 
 RESOURCE_DEFINITION
@@ -1376,7 +1416,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/MON3
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/MON3
 }
 
 RESOURCE_DEFINITION
@@ -1389,7 +1429,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/MON10
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/MON10
 }
 
 RESOURCE_DEFINITION
@@ -1402,7 +1442,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/MON15
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/MON15
 }
 
 RESOURCE_DEFINITION
@@ -1415,7 +1455,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/MON20
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/MON20
 }
 
 RESOURCE_DEFINITION
@@ -1465,7 +1505,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/Nitrogen
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Nitrogen
 }
 
 RESOURCE_DEFINITION
@@ -1478,7 +1518,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/NitrousOxide
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/NitrousOxide
 }
 
 RESOURCE_DEFINITION
@@ -1491,7 +1531,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/NTO
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/N2O4
 }
 
 RESOURCE_DEFINITION
@@ -1553,7 +1593,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/Syntin
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/Syntin
 }
 
 RESOURCE_DEFINITION
@@ -1565,7 +1605,7 @@ RESOURCE_DEFINITION
     transfer = NONE
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/TEATEB
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/TEATEB
 }
 
 RESOURCE_DEFINITION
@@ -1602,7 +1642,7 @@ RESOURCE_DEFINITION
     transfer = PUMP
     isTweakable = True
     isVisible = true
-    ksparpicon = RealFuels/Resources/ARPIcons/UDMH
+    ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/UDMH
 }
 
 RESOURCE_DEFINITION


### PR DESCRIPTION
This makes it easier to determine which resources are missing icons.

Also, prefer the KSPARP version of an icon over the RealFuels version, if
it exists and is the same.