### PR TITLE
Added Decaborane as a resource

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -695,6 +695,18 @@ RESOURCE_DEFINITION
 
 RESOURCE_DEFINITION
 {
+	abbreviation = DeBo
+	name = Decaborane
+	density = 0.00094
+	flowMode = STAGE_PRIORITY_FLOW
+	transfer = PUMP
+	isTweakable = true
+	isVisible = true
+	unitCost = 3.252
+}
+
+RESOURCE_DEFINITION
+{
 	abbreviation = D
 	name = Deuterium
 	density = 0.000000180 


### PR DESCRIPTION
Added Decaborane, a resource which is usefull as either fusion fuel or as additive in Chemical Propusion