### PR TITLE
Added Resource Hexaborane

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -958,6 +958,17 @@ RESOURCE_DEFINITION
 
 RESOURCE_DEFINITION
 {
+   	name = Hexaborane
+   	density = 0.000670
+   	flowMode = ALL_VESSEL
+   	transfer = PUMP
+   	isTweakable = true
+   	unitCost = 7.3
+	volume = 1
+}
+
+RESOURCE_DEFINITION
+{
 	abbreviation = N14
 	name = LqdNitrogen
 	density = 0.000824907

--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -963,7 +963,7 @@ RESOURCE_DEFINITION
    	flowMode = ALL_VESSEL
    	transfer = PUMP
    	isTweakable = true
-   	unitCost = 7.3
+   	unitCost = 0.25
 	volume = 1
 }
 


### PR DESCRIPTION
Added Resource Hexaborane, a liquid variant of Hydrogen-Boron11 An aneutronic Fusion fuel. Cost based on NF Boron