### PR TITLE
Added Resources LithiumHydride and LithiumDeuteride

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -883,6 +883,32 @@ RESOURCE_DEFINITION
 
 RESOURCE_DEFINITION
 {
+	abbreviation = Li7H
+	name = LithiumHydride
+	title = LithiumHydride
+	density = 0.00078  
+	unitCost = 0.0006675
+	flowMode = STAGE_PRIORITY_FLOW
+	transfer = PUMP
+	isTweakable = true
+	volume = 1
+}
+
+RESOURCE_DEFINITION
+{
+	abbreviation = Li6D
+	name = LithiumDeuteride
+	title = LithiumDeuteride
+	density = 0.00082  
+	unitCost = 5
+	flowMode = STAGE_PRIORITY_FLOW
+	transfer = PUMP
+	isTweakable = true
+	volume = 1
+}
+
+RESOURCE_DEFINITION
+{
 	abbreviation = NH3
 	name = LqdAmmonia
 	density = 0.0007021

--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -887,7 +887,7 @@ RESOURCE_DEFINITION
 	name = LithiumHydride
 	title = LithiumHydride
 	density = 0.00078  
-	unitCost = 0.0006675
+	unitCost = 0.4
 	flowMode = STAGE_PRIORITY_FLOW
 	transfer = PUMP
 	isTweakable = true


### PR DESCRIPTION
LithiumHydride  can be used as either nuclear radiation shielding or as a solid aneutronic fusion fuel. LithiumDeuteride can be used for fusion bombs or low tech Fusion Fuel. Cost based on lithium