### PR TITLE
Added Resource Tritium as gas

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -1166,6 +1166,19 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
 	abbreviation = T
+	name = Tritium
+	title = Tritium Gas
+	density = 0.0000002705   
+	unitCost = 0.016
+	flowMode = STAGE_PRIORITY_FLOW
+	transfer = PUMP
+	isTweakable = true
+	volume = 1
+}
+
+RESOURCE_DEFINITION
+{
+	abbreviation = T
 	name = LqdTritium
 	density = 0.000320
 	flowMode = STAGE_PRIORITY_FLOW


### PR DESCRIPTION
When Tritium is created or extracted, it is never in a Liquid Form, but in it Gas Form