### PR TITLE
Added Resource FusionPellets

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -788,6 +788,17 @@ RESOURCE_DEFINITION
 
 RESOURCE_DEFINITION
 {
+	name = FusionPellets
+	density = 0.000216
+	unitCost = 150
+	flowMode = STAGE_PRIORITY_FLOW
+	transfer = PUMP
+	isTweakable = true
+	volume = 1
+}
+
+RESOURCE_DEFINITION
+{
 	abbreviation = F
 	name = Fluorine
 	density = 0.000001696


### PR DESCRIPTION
FusionPellets represent D-He3 fusion pellet which is also in use by DSEV and will also be used by Near Future