### PR TITLE
Delete empty config file

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -541,7 +541,8 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
 	name = ArgonGas // Common electric engine propellant
-	displayName = ArgonGas // Common electric engine propellant
+	displayName = #LOC_CRP_ArgonGas_DisplayName // Common electric engine propellant
+	abbreviation = #LOC_CRP_ArgonGas_Abbreviation
 	density = 0.00000178400
 	unitCost = 0.0105
 	flowMode = STAGE_PRIORITY_FLOW
@@ -556,7 +557,8 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
 	name = Boron
-	displayName = Boron
+	displayName = #LOC_CRP_Boron_DisplayName
+	abbreviation = #LOC_CRP_Boron_Abbreviation
 	density = 0.00246000000
 	unitCost = 0.851
 	flowMode = STAGE_PRIORITY_FLOW
@@ -581,8 +583,9 @@ RESOURCE_DEFINITION
 
 RESOURCE_DEFINITION
 {
-	name = DepletedUranium // Depleted fuel to preserve mass when burned, can be recycled
-	displayName = DepletedUranium // Depleted fuel to preserve mass when burned, can be recycled
+	name = DepletedUranium
+	displayName =  #LOC_CRP_DepletedUranium_DisplayName // Depleted fuel to preserve mass when burned, can be recycled
+	abbreviation =  #LOC_CRP_DepletedUranium_Abbreviation // Depleted fuel to preserve mass when burned, can be recycled
 	unitCost = 0
 	density = 0.01097000000
 	flowMode = NO_FLOW
@@ -595,8 +598,9 @@ RESOURCE_DEFINITION
 
 RESOURCE_DEFINITION
 {
-	name = EnrichedUranium // Nuclear fuel
-	displayName = EnrichedUranium // Nuclear fuel
+	name = EnrichedUranium
+	dispalyName = #LOC_CRP_EnrichedUranium_DisplayName // Nuclear fuel
+	abbreviation = #LOC_CRP_EnrichedUranium_Abbreviation // Nuclear fuel
 	density = 0.01097000000
 	unitCost = 865.0000000
 	isTweakable = true
@@ -609,8 +613,9 @@ RESOURCE_DEFINITION
 
 RESOURCE_DEFINITION
 {
-	name = LqdHydrogen // General propellant, used for high thrust electric engines
-	displayName = LqdHydrogen // General propellant, used for high thrust electric engines
+	name = LqdHydrogen
+	displayName = #LOC_CRP_LqdHydrogen_DisplayName // General propellant
+	abbreviation = #LOC_CRP_LqdHydrogen_Abbreviation // General propellant
 	density = 0.00007085000
 	unitCost = 0.0367500
 	hsp = 9690 // specific heat capacity (kJ/tonne-K as units) at Crygenic Storage temperature
@@ -625,8 +630,9 @@ RESOURCE_DEFINITION
 
 RESOURCE_DEFINITION
 {
-	name = StoredCharge // Capacitor resource. Translates to Ec
-	displayName = StoredCharge // Capacitor resource. Translates to Ec
+	name = StoredCharge
+	displayName =  #LOC_CRP_StoredCharge_DisplayName  // Capacitor resource. Translates to Ec
+	abbreviation = #LOC_CRP_StoredCharge_Abbreviation // Capacitor resource. Translates to Ec
 	unitCost = 0
 	density = 0
 	flowMode = NO_FLOW

--- a/FOR_RELEASE/GameData/CommunityResourcePack/Localization/en-us.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/Localization/en-us.cfg
@@ -1,0 +1,19 @@
+Localization
+{
+	en-us
+	{
+	
+		#LOC_CRP_ArgonGas_DisplayName = Argon Gas
+		#LOC_CRP_ArgonGas_Abbreviation = Ar
+		#LOC_CRP_Boron_DisplayName = Boron
+		#LOC_CRP_Boron_Abbreviation = Bo
+		#LOC_CRP_EnrichedUranium_DisplayName = Enriched Uranium
+		#LOC_CRP_EnrichedUranium_Abbreviation = EnrU
+		#LOC_CRP_DepletedUranium_DisplayName = Depleted Uranium
+		#LOC_CRP_DepletedUranium_Abbreviation = DepU
+		#LOC_CRP_LqdHydrogen_DisplayName = Liquid Hydrogen
+		#LOC_CRP_LqdHydrogen_Abbreviation = LH2
+		#LOC_CRP_StoredCharge_DisplayName = Stored Charge
+		#LOC_CRP_StoredCharge_Abbreviation = SC
+	}
+}


### PR DESCRIPTION
The presence of this empty file seems to make PartTools misbehave. Perhaps we should remove it?