### PR TITLE
Curator Change For FusionPellets

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -881,18 +881,6 @@ RESOURCE_DEFINITION
 
 RESOURCE_DEFINITION
 {
-	name = FusionPellets
-	displayName = FusionPellets
-	density = 0.000216
-	unitCost = 150
-	flowMode = STAGE_PRIORITY_FLOW
-	transfer = PUMP
-	isTweakable = true
-	volume = 1
-}
-
-RESOURCE_DEFINITION
-{
 	abbreviation = F
 	name = Fluorine
 	displayName = Fluorine
@@ -2259,6 +2247,22 @@ RESOURCE_DEFINITION
    isTweakable = true   
    ksparpicon = REPOSoftTech/DeepFreeze/Icons/Glykerol
    ksparpdisplayvalueas = Units
+}
+
+//****************************************
+//* SECTION 6 Wild Blue Industries Curated
+//****************************************
+
+RESOURCE_DEFINITION
+{
+	name = FusionPellets
+	displayName = FusionPellets
+	density = 0.000216
+	unitCost = 150
+	flowMode = STAGE_PRIORITY_FLOW
+	transfer = PUMP
+	isTweakable = true
+	volume = 1
 }
 
 //******************************


### PR DESCRIPTION
FusionPellets is a resource that's been use by Wild Blue Industries mod
for nearly 3 years. It is currently being incorrectly curated by KSPI-E.
This change fixes the curator.