### PR TITLE
FusionPellets Curator Fix

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -934,19 +934,7 @@ RESOURCE_DEFINITION
     ksparpicon = TriggerTech/KSPAlternateResourcePanel/Icons/ExoticMatter
 }
 
-RESOURCE_DEFINITION
-{
-	name = FusionPellets
-	displayName = #LOC_CRP_FusionPellets_DisplayName
-	density = 0.000216
-	unitCost = 150
-	flowMode = STAGE_PRIORITY_FLOW
-	transfer = PUMP
-	isTweakable = true
-	volume = 1
-}
 
-RESOURCE_DEFINITION
 {
 	abbreviation = #LOC_CRP_Fluorine_Abbreviation
 	name = Fluorine
@@ -2404,6 +2392,22 @@ RESOURCE_DEFINITION
    isTweakable = true
    ksparpicon = REPOSoftTech/DeepFreeze/Icons/Glykerol
    ksparpdisplayvalueas = Units
+}
+
+//****************************************
+//* SECTION 6 Wild Blue Industries Curated
+//****************************************
+
+RESOURCE_DEFINITION
+{
+	name = FusionPellets
+	displayName = #LOC_CRP_FusionPellets_DisplayName
+	density = 0.000216
+	unitCost = 150
+	flowMode = STAGE_PRIORITY_FLOW
+	transfer = PUMP
+	isTweakable = true
+	volume = 1
 }
 
 //******************************

--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -935,6 +935,7 @@ RESOURCE_DEFINITION
 }
 
 
+RESOURCE_DEFINITION
 {
 	abbreviation = #LOC_CRP_Fluorine_Abbreviation
 	name = Fluorine


### PR DESCRIPTION
FusionPellets is a resource created for use by Wild Blue Industries mods
in 2014. It is incorrectly being currated by KSPI-E. This fix adds the
correct currator.