### PR TITLE
Update version file to mark current release as supporting KSP 1.7

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CRP.version
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CRP.version
@@ -25,7 +25,6 @@
      },
      "KSP_VERSION_MAX":{
          "MAJOR":1,
-         "MINOR":6,
-         "PATCH":9
+         "MINOR":7
      }
  } 


### PR DESCRIPTION
CKAN users are encountering blocks when trying to install dependent mods on current game versions because CRP only supports up to KSP 1.6:

![screenshot](https://cdn.discordapp.com/attachments/206181796164009984/596806513918476293/unknown.png)

Luckily, updating the remote version file (the one pointed to by the `"URL"` property) can update the compatibility without a new release.

If the current version of CRP is compatible with and supported on KSP 1.7, merging this pull request will mark it as such. Otherwise just close it.

Closes #241 (which is changing the `"VERSION"` property, which would make this not work).