### PR TITLE
Fix version file version

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CRP.version
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CRP.version
@@ -9,14 +9,14 @@
      },
      "VERSION":{
          "MAJOR":1,
-         "MINOR":2,
+         "MINOR":3,
          "PATCH":0,
          "BUILD":0
      },
      "KSP_VERSION":{
          "MAJOR":1,
-         "MINOR":7,
-         "PATCH":3
+         "MINOR":8,
+         "PATCH":0
      },
      "KSP_VERSION_MIN":{
          "MAJOR":1,


### PR DESCRIPTION
@BobPalmer I didn't notice in #244 that the version file's `"VERSION"` property was out of date; the current download is 1.3.0.0, but the online version file has 1.2.0.0. This prevented #244 from having any effect in CKAN.

Now this is fixed and should have an effect.