### PR TITLE
Fixed density of ammonia

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CommonResources.cfg
@@ -697,7 +697,7 @@ RESOURCE_DEFINITION
 	name = Ammonia
 	abbreviation = #LOC_CRP_Ammonia_Abbreviation
 	displayName = #LOC_CRP_Ammonia_DisplayName
-	density = 0.000000769
+	density = 0.000769
 	unitCost = 0.00015
 	hsp = 2175
 	flowMode = STAGE_PRIORITY_FLOW


### PR DESCRIPTION
Density was off by factor of 1000, most likely was g/cm instead of g/L.