### PR TITLE
De-bump VERSION property of version file

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CRP.version
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CRP.version
@@ -9,7 +9,7 @@
      },
      "VERSION":{
          "MAJOR":1,
-         "MINOR":4,
+         "MINOR":3,
          "PATCH":0,
          "BUILD":0
      },


### PR DESCRIPTION
Unfortunately #249 had the exact opposite effect of what it tried to achieve.
As I wrote in my comment on that PR, the `VERSION` property should've stayed the same as it is in the version file that's included in the already released zip (`1.3.0.0`).
Now that they differ, CKAN and AVC ignore the upstream version file.

That lead to the netkan bot decreasing `KSP_VERSION_MAX` to `1.8.9` again:
https://github.com/KSP-CKAN/CKAN-meta/commit/ccb01a95538d62c99145af0545fb4e5b19ad73ba

This PR decreases the `VERSION` to `1.3.0.0` again, so that the latest released version finally gets to enjoy the benefits of no upper KSP version bound.

Pinging @BobPalmer in case you have PR notifications turned off.