### PR TITLE
Fix version file syntax error (missing comma)

### DIFF
--- a/FOR_RELEASE/GameData/CommunityResourcePack/CRP.version
+++ b/FOR_RELEASE/GameData/CommunityResourcePack/CRP.version
@@ -22,7 +22,7 @@
          "MAJOR":1,
          "MINOR":6,
          "PATCH":0
-     }
+     },
      "KSP_VERSION_MAX":{
          "MAJOR":1,
          "MINOR":99,


### PR DESCRIPTION
The version file currently has a syntax error as of a53e9941491b0d56c26bfe6285ff6bbbae604581, a new property was added without a comma separating it from the previous property, so those changes will not have been picked up. Now it's fixed.

Tagging @BobPalmer because GitHub likes to not send pull request notifications otherwise.

Once again a plug for @DasSkelett's great validation tool for version files to catch things like this:
- https://github.com/DasSkelett/AVC-VersionFileValidator